### PR TITLE
[2015-2016) Secret Wars (Simplified)

### DIFF
--- a/Marvel/Events/CBH/[2015] Secret Wars (Simplified).cbl
+++ b/Marvel/Events/CBH/[2015] Secret Wars (Simplified).cbl
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Name>[2015] Secret Wars (Simplified)</Name>
+<NumIssues>60</NumIssues>
+<Books>
+<Book Series="Avengers" Number="35" Volume="2012" Year="2014">
+<Database Name="cv" Series="54428" Issue="465837" />
+</Book>
+<Book Series="New Avengers" Number="24" Volume="2013" Year="2014">
+<Database Name="cv" Series="55330" Issue="466332" />
+</Book>
+<Book Series="Avengers" Number="36" Volume="2012" Year="2014">
+<Database Name="cv" Series="54428" Issue="467647" />
+</Book>
+<Book Series="New Avengers" Number="25" Volume="2013" Year="2014">
+<Database Name="cv" Series="55330" Issue="468084" />
+</Book>
+<Book Series="Avengers" Number="37" Volume="2012" Year="2014">
+<Database Name="cv" Series="54428" Issue="468457" />
+</Book>
+<Book Series="New Avengers" Number="26" Volume="2013" Year="2015">
+<Database Name="cv" Series="55330" Issue="470433" />
+</Book>
+<Book Series="Avengers" Number="38" Volume="2012" Year="2015">
+<Database Name="cv" Series="54428" Issue="470417" />
+</Book>
+<Book Series="New Avengers" Number="27" Volume="2013" Year="2015">
+<Database Name="cv" Series="55330" Issue="471318" />
+</Book>
+<Book Series="Avengers" Number="39" Volume="2012" Year="2015">
+<Database Name="cv" Series="54428" Issue="472900" />
+</Book>
+<Book Series="New Avengers" Number="28" Volume="2013" Year="2015">
+<Database Name="cv" Series="55330" Issue="474632" />
+</Book>
+<Book Series="Avengers" Number="40" Volume="2012" Year="2015">
+<Database Name="cv" Series="54428" Issue="475932" />
+</Book>
+<Book Series="New Avengers" Number="29" Volume="2013" Year="2015">
+<Database Name="cv" Series="55330" Issue="477851" />
+</Book>
+<Book Series="Avengers" Number="41" Volume="2012" Year="2015">
+<Database Name="cv" Series="54428" Issue="478606" />
+</Book>
+<Book Series="New Avengers" Number="30" Volume="2013" Year="2015">
+<Database Name="cv" Series="55330" Issue="480676" />
+</Book>
+<Book Series="Avengers" Number="42" Volume="2012" Year="2015">
+<Database Name="cv" Series="54428" Issue="481605" />
+</Book>
+<Book Series="New Avengers" Number="31" Volume="2013" Year="2015">
+<Database Name="cv" Series="55330" Issue="482160" />
+</Book>
+<Book Series="Avengers" Number="43" Volume="2012" Year="2015">
+<Database Name="cv" Series="54428" Issue="484889" />
+</Book>
+<Book Series="New Avengers" Number="32" Volume="2013" Year="2015">
+<Database Name="cv" Series="55330" Issue="483355" />
+</Book>
+<Book Series="Avengers" Number="44" Volume="2012" Year="2015">
+<Database Name="cv" Series="54428" Issue="487201" />
+</Book>
+<Book Series="New Avengers" Number="33" Volume="2013" Year="2015">
+<Database Name="cv" Series="55330" Issue="487208" />
+</Book>
+<Book Series="Free Comic Book Day 2015 (Secret Wars)" Number="0" Volume="2015" Year="2015">
+<Database Name="cv" Series="81729" Issue="487501" />
+</Book>
+<Book Series="Secret Wars" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="81833" Issue="487843" />
+</Book>
+<Book Series="Secret Wars" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="81833" Issue="488656" />
+</Book>
+<Book Series="Thors" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="82716" Issue="492227" />
+</Book>
+<Book Series="The Infinity Gauntlet" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="82203" Issue="489902" />
+</Book>
+<Book Series="Secret Wars" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="81833" Issue="490887" />
+</Book>
+<Book Series="Thors" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="82716" Issue="496400" />
+</Book>
+<Book Series="A-Force" Number="1" Volume="2016" Year="2016">
+<Database Name="cv" Series="87152" Issue="510488" />
+</Book>
+<Book Series="A-Force" Number="2" Volume="2016" Year="2016">
+<Database Name="cv" Series="87152" Issue="513637" />
+</Book>
+<Book Series="Secret Wars Journal" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="82210" Issue="489912" />
+</Book>
+<Book Series="Secret Wars" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="81833" Issue="493798" />
+</Book>
+<Book Series="Ultimate End" Number="1" Volume="2016" Year="2015">
+<Database Name="cv" Series="82109" Issue="489329" />
+</Book>
+<Book Series="Ultimate End" Number="2" Volume="2016" Year="2015">
+<Database Name="cv" Series="82109" Issue="491531" />
+</Book>
+<Book Series="Ultimate End" Number="3" Volume="2016" Year="2015">
+<Database Name="cv" Series="82109" Issue="493803" />
+</Book>
+<Book Series="The Infinity Gauntlet" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="82203" Issue="493043" />
+</Book>
+<Book Series="The Infinity Gauntlet" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="82203" Issue="496884" />
+</Book>
+<Book Series="Thors" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="82716" Issue="499048" />
+</Book>
+<Book Series="Secret Wars" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="81833" Issue="497397" />
+</Book>
+<Book Series="Siege" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="83322" Issue="495278" />
+</Book>
+<Book Series="Siege" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="83322" Issue="496889" />
+</Book>
+<Book Series="Marvel Zombies" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="82505" Issue="491519" />
+</Book>
+<Book Series="Marvel Zombies" Number="2" Volume="2015" Year="2015">
+<Database Name="cv" Series="82505" Issue="495803" />
+</Book>
+<Book Series="Secret Wars: Battleworld" Number="1" Volume="2015" Year="2015">
+<Database Name="cv" Series="82107" Issue="489326" />
+</Book>
+<Book Series="Secret Wars Journal" Number="5" Volume="2015" Year="2015">
+<Database Name="cv" Series="82210" Issue="500306" />
+</Book>
+<Book Series="Secret Wars" Number="6" Volume="2015" Year="2015">
+<Database Name="cv" Series="81833" Issue="502130" />
+</Book>
+<Book Series="Thors" Number="4" Volume="2015" Year="2016">
+<Database Name="cv" Series="82716" Issue="505528" />
+</Book>
+<Book Series="The Infinity Gauntlet" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="82203" Issue="500304" />
+</Book>
+<Book Series="The Infinity Gauntlet" Number="5" Volume="2015" Year="2016">
+<Database Name="cv" Series="82203" Issue="505520" />
+</Book>
+<Book Series="Ultimate End" Number="4" Volume="2016" Year="2015">
+<Database Name="cv" Series="82109" Issue="496891" />
+</Book>
+<Book Series="Secret Wars" Number="7" Volume="2015" Year="2016">
+<Database Name="cv" Series="81833" Issue="505522" />
+</Book>
+<Book Series="Siege" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="83322" Issue="499754" />
+</Book>
+<Book Series="Siege" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="83322" Issue="502131" />
+</Book>
+<Book Series="A-Force" Number="3" Volume="2016" Year="2016">
+<Database Name="cv" Series="87152" Issue="517822" />
+</Book>
+<Book Series="A-Force" Number="4" Volume="2016" Year="2016">
+<Database Name="cv" Series="87152" Issue="525014" />
+</Book>
+<Book Series="Marvel Zombies" Number="3" Volume="2015" Year="2015">
+<Database Name="cv" Series="82505" Issue="498393" />
+</Book>
+<Book Series="Marvel Zombies" Number="4" Volume="2015" Year="2015">
+<Database Name="cv" Series="82505" Issue="502869" />
+</Book>
+<Book Series="Ultimate End" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="82109" Issue="508440" />
+</Book>
+<Book Series="Secret Wars" Number="8" Volume="2015" Year="2016">
+<Database Name="cv" Series="81833" Issue="507780" />
+</Book>
+<Book Series="Secret Wars" Number="9" Volume="2015" Year="2016">
+<Database Name="cv" Series="81833" Issue="510951" />
+</Book>
+<Book Series="A-Force" Number="5" Volume="2016" Year="2016">
+<Database Name="cv" Series="87152" Issue="528496" />
+</Book>
+</Books>
+<Matchers />
+</ReadingList>


### PR DESCRIPTION
A More streamlined reading order for secret wars, omitting a lot of unnecessary/optional tie-ins that may scare off newer readers (like myself) looking to read the event in it's entirety. This was mainly curated with help by CBH, but perfecting the order as well as the chronology was somewhat of a personal endeavor. 

https://www.comicbookherald.com/the-complete-marvel-reading-order-guide/secret-wars-reading-order/ 
https://www.comicbookherald.com/the-complete-marvel-reading-order-guide/secret-wars-reading-order/battleworld-warzone-last-days-checklists/